### PR TITLE
Use @Column default length = 0, to support Postgres varchar/text with out any length

### DIFF
--- a/jakarta-persistence-api/pom.xml
+++ b/jakarta-persistence-api/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>org.avaje</groupId>
     <artifactId>java11-oss</artifactId>
-    <version>3.9</version>
+    <version>4.5</version>
   </parent>
 
   <groupId>io.ebean</groupId>
   <artifactId>jakarta-persistence-api</artifactId>
-  <version>3.0-RC1</version>
+  <version>3.1</version>
 
   <build>
     <plugins>

--- a/javax-persistence-api/pom.xml
+++ b/javax-persistence-api/pom.xml
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
-  <groupId>io.ebean</groupId>
-  <artifactId>persistence-api</artifactId>
-  <version>3.1-SNAPSHOT</version>
-
   <parent>
     <groupId>org.avaje</groupId>
     <artifactId>java11-oss</artifactId>
-    <version>3.9</version>
+    <version>4.5</version>
   </parent>
+
+  <groupId>io.ebean</groupId>
+  <artifactId>persistence-api</artifactId>
+  <version>3.1</version>
 
   <licenses>
     <license>

--- a/javax-persistence-api/src/main/java/javax/persistence/Column.java
+++ b/javax-persistence-api/src/main/java/javax/persistence/Column.java
@@ -99,7 +99,7 @@ public @interface Column {
    * (Optional) The column length. (Applies only if a
    * string-valued column is used.)
    */
-  int length() default 255;
+  int length() default 0;
 
   /**
    * (Optional) The precision for a decimal (exact numeric)

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.avaje</groupId>
     <artifactId>java11-oss</artifactId>
-    <version>3.9</version>
+    <version>4.5</version>
   </parent>
 
   <groupId>io.ebean</groupId>


### PR DESCRIPTION
This means that @Column(length=255) can now mean varchar(255).